### PR TITLE
Persist risk state across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 config.toml
 .env
 *.log
+state/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy==2.2.2
 pydantic==2.10.6
 tomli==2.0.1; python_version < '3.11'
 rich==13.9.4
+pytest==8.3.4

--- a/spybot/__init__.py
+++ b/spybot/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/spybot/risk.py
+++ b/spybot/risk.py
@@ -17,11 +17,18 @@ class RiskState:
 
 
 class RiskManager:
-    def __init__(self, *, max_position_pct: float, max_daily_loss_usd: float, max_drawdown_pct: float):
+    def __init__(
+        self,
+        *,
+        max_position_pct: float,
+        max_daily_loss_usd: float,
+        max_drawdown_pct: float,
+        state: RiskState | None = None,
+    ):
         self.max_position_pct = max_position_pct / 100.0
         self.max_daily_loss_usd = float(max_daily_loss_usd)
         self.max_drawdown_pct = max_drawdown_pct / 100.0
-        self.state = RiskState()
+        self.state = state or RiskState()
 
     def update_equity(self, acct: AccountState) -> None:
         now = datetime.now(timezone.utc)

--- a/spybot/runner.py
+++ b/spybot/runner.py
@@ -30,10 +30,18 @@ def run_bot_once(cfg: Config, *, dry_run: bool = False) -> None:
     log.info(f"Symbol: {cfg.market.symbol}")
     log.info(f"Dry run: {dry_run}")
 
+    # Load risk state from disk so limits remain enforced across restarts.
+    from pathlib import Path
+    from .state import default_state_path, load_risk_state, save_risk_state
+
+    state_path = default_state_path()
+    loaded_state = load_risk_state(state_path)
+
     risk = RiskManager(
         max_position_pct=cfg.risk.max_position_pct,
         max_daily_loss_usd=cfg.risk.max_daily_loss_usd,
         max_drawdown_pct=cfg.risk.max_drawdown_pct,
+        state=loaded_state,
     )
 
     strat = SpySwingStrategy(
@@ -56,6 +64,7 @@ def run_bot_once(cfg: Config, *, dry_run: bool = False) -> None:
     try:
         acct = broker.get_account_state()
         risk.update_equity(acct)
+        save_risk_state(state_path, risk.state)
 
         ok_dd, msg_dd = risk.check_drawdown(acct)
         ok_dl, msg_dl = risk.check_daily_loss(acct)

--- a/spybot/state.py
+++ b/spybot/state.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from .risk import RiskState
+
+
+def default_state_path() -> Path:
+    # Keep state local to the repo by default.
+    return Path("state") / "risk_state.json"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_risk_state(path: Path) -> RiskState:
+    """Load RiskState from JSON. Returns empty RiskState if file does not exist."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return RiskState()
+
+    if not isinstance(data, dict):
+        return RiskState()
+
+    return RiskState(
+        starting_equity=data.get("starting_equity"),
+        day_start_equity=data.get("day_start_equity"),
+        day_start_date=data.get("day_start_date"),
+    )
+
+
+def save_risk_state(path: Path, state: RiskState) -> None:
+    """Persist RiskState to JSON with restrictive permissions when possible."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict[str, Any] = {
+        "starting_equity": state.starting_equity,
+        "day_start_equity": state.day_start_equity,
+        "day_start_date": state.day_start_date,
+        "last_updated_utc": _utc_now_iso(),
+    }
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    # Best-effort permission tightening.
+    try:
+        os.chmod(tmp, 0o600)
+    except Exception:
+        pass
+
+    tmp.replace(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure repo root is importable for tests without packaging.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from spybot.risk import RiskState
+from spybot.state import load_risk_state, save_risk_state
+
+
+def test_load_missing(tmp_path: Path):
+    p = tmp_path / "risk_state.json"
+    st = load_risk_state(p)
+    assert st == RiskState()
+
+
+def test_roundtrip(tmp_path: Path):
+    p = tmp_path / "risk_state.json"
+    st = RiskState(starting_equity=100.0, day_start_equity=95.0, day_start_date="2026-02-14")
+    save_risk_state(p, st)
+    st2 = load_risk_state(p)
+    assert st2.starting_equity == 100.0
+    assert st2.day_start_equity == 95.0
+    assert st2.day_start_date == "2026-02-14"


### PR DESCRIPTION
## What
Persist RiskManager state (starting equity + day-start equity/date) to a local JSON file so daily-loss and drawdown limits remain enforced across restarts.

## Why
Without persistence, a process restart resets risk tracking, weakening safety guarantees and potentially allowing trades that should be blocked by the daily loss / drawdown caps.

## How
- Add `spybot/state.py` with `load_risk_state` / `save_risk_state` (JSON, best-effort 0600 permissions).
- Inject loaded state into `RiskManager` at startup.
- Save state after updating equity.
- Ignore `state/` directory in git.
- Add a small unit test for state round-trip.

## Risks / mitigations
- **Correctness**: day boundaries use UTC date string; aligns with existing UTC-based risk tracking.
- **Security**: state contains no secrets; permissions tightened best-effort; file kept local.
- **Reversibility**: delete `state/risk_state.json` to reset; revert commit to remove persistence.

## Notes
This does not change live trading behavior; it strengthens existing risk limits.