### PR TITLE
Fix pandas resample deprecation for 4h timeframe

### DIFF
--- a/spybot/runner.py
+++ b/spybot/runner.py
@@ -78,7 +78,7 @@ def run_bot_once(cfg: Config, *, dry_run: bool = False) -> None:
 
         if cfg.timeframes.primary == "4h":
             from .timeframes import resample_ohlcv
-            bars = resample_ohlcv(bars_1h, "4H")
+            bars = resample_ohlcv(bars_1h, "4h")
         else:
             bars = bars_1h
 


### PR DESCRIPTION
## What
Switch resample rule from `4H` to `4h` in runner.

## Why
Pandas emits a FutureWarning that uppercase `H` is deprecated. This creates noise in logs and can mask real warnings.

## Risk
Low, behavior-equivalent formatting change only.

## Validation
Ran bot against IBKR paper; warning no longer appears and run completes normally.
