### PR TITLE
Add IB Gateway watchdog automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,23 @@ python -m spybot run --config config.toml
 - This bot is designed for **swing** trading using **1H bars** and a **4H primary timeframe** (recommended).
 - It will refuse to place orders if any risk limit is breached.
 
+## Optional: IB Gateway watchdog (no-VNC routine operations)
+This watchdog checks if IBKR API port `7497` is reachable and requests a restart of `ibgateway.service` when down.
+
+Install user units:
+```bash
+mkdir -p ~/.config/systemd/user
+cp ops/systemd/ibgateway-watchdog.service ~/.config/systemd/user/
+cp ops/systemd/ibgateway-watchdog.timer ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now ibgateway-watchdog.timer
+```
+
+Inspect status/logs:
+```bash
+systemctl --user status ibgateway-watchdog.timer --no-pager
+journalctl --user -u ibgateway-watchdog.service -n 50 --no-pager
+```
+
+Caveat: IBKR may still require occasional manual login/2FA/disclaimer interaction in VNC.
+

--- a/ops/gateway_watchdog.py
+++ b/ops/gateway_watchdog.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Simple IB Gateway watchdog.
+
+- Checks if API port is listening.
+- Restarts `ibgateway.service` (systemd --user) when down.
+- Writes state transitions to stdout for journald.
+
+Designed for use with a systemd user timer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def port_open(host: str, port: int, timeout: float = 2.0) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        try:
+            s.connect((host, port))
+            return True
+        except OSError:
+            return False
+
+
+def read_state(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return "UNKNOWN"
+
+
+def write_state(path: Path, state: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(state + "\n", encoding="utf-8")
+
+
+def run_cmd(cmd: list[str]) -> tuple[int, str]:
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    out = (p.stdout or "") + (p.stderr or "")
+    return p.returncode, out.strip()
+
+
+def restart_ibgateway() -> tuple[bool, str]:
+    code, out = run_cmd(["systemctl", "--user", "restart", "ibgateway.service"])
+    return code == 0, out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=7497)
+    ap.add_argument("--state-file", default="state/watchdog_ibgateway.state")
+    args = ap.parse_args()
+
+    state_file = Path(args.state_file)
+    prev = read_state(state_file)
+
+    up = port_open(args.host, args.port)
+    cur = "UP" if up else "DOWN"
+
+    if cur != prev:
+        print(f"[{now_utc()}] WATCHDOG state change: {prev} -> {cur}")
+
+    if not up:
+        print(f"[{now_utc()}] WATCHDOG action: restarting ibgateway.service")
+        ok, out = restart_ibgateway()
+        if not ok:
+            print(f"[{now_utc()}] WATCHDOG restart failed: {out}")
+            write_state(state_file, "DOWN")
+            return 1
+        print(f"[{now_utc()}] WATCHDOG restart requested")
+
+    write_state(state_file, cur)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/systemd/ibgateway-watchdog.service
+++ b/ops/systemd/ibgateway-watchdog.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=IB Gateway API watchdog (user)
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.openclaw/workspace/projects/spy-swing-bot
+ExecStart=%h/.openclaw/workspace/projects/spy-swing-bot/.venv/bin/python %h/.openclaw/workspace/projects/spy-swing-bot/ops/gateway_watchdog.py --host 127.0.0.1 --port 7497 --state-file %h/.openclaw/workspace/projects/spy-swing-bot/state/watchdog_ibgateway.state

--- a/ops/systemd/ibgateway-watchdog.timer
+++ b/ops/systemd/ibgateway-watchdog.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run IB Gateway watchdog every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Unit=ibgateway-watchdog.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What
Add an IB Gateway watchdog to reduce manual VNC intervention in normal operations.

### Included
- `ops/gateway_watchdog.py`:
  - checks API socket (`127.0.0.1:7497`)
  - requests `systemctl --user restart ibgateway.service` when API is down
  - stores simple UP/DOWN state for transition logging
- `ops/systemd/ibgateway-watchdog.service`
- `ops/systemd/ibgateway-watchdog.timer` (every minute)
- README instructions to install/enable the timer.

## Why
You asked to run tests and operations without needing to manually open VNC each time.
This adds automatic recovery for common gateway down states.

## Risk assessment
- **Safety**: no trading logic changes; watchdog only checks socket + restart request.
- **Correctness**: false positives are possible if Gateway is starting slowly; restart interval is conservative (1 min).
- **Security**: runs as user-level systemd service; no new secrets introduced.

## Reversibility
Disable/remove timer and service:
```bash
systemctl --user disable --now ibgateway-watchdog.timer
rm ~/.config/systemd/user/ibgateway-watchdog.{service,timer}
systemctl --user daemon-reload
```

## Caveat
IBKR can still require occasional manual login/2FA/disclaimer acceptance in VNC.
