### PR TITLE
Add signal journaling and learning notes updates

### DIFF
--- a/lessons.md
+++ b/lessons.md
@@ -12,3 +12,9 @@ Suggested structure:
 ---
 
 _No lessons yet._
+
+- Date: 2026-02-19
+- Observation: Account-level tradability constraints vary significantly by instrument and venue.
+- Evidence: Paper probes showed EURUSD/GBPUSD roundtrip fills while SPY/QQQ/IWM rejected (KID), CSPX/VUAA stuck pre-submitted in test window, BTC/ETH required cash-quantity order model.
+- Decision / change made: Prioritize FX instruments (EURUSD/GBPUSD) for execution-path validation and learning loops.
+- Result: Confirmed reliable order submit/fill/close path in paper mode for EURUSD/GBPUSD.

--- a/research.md
+++ b/research.md
@@ -12,3 +12,15 @@ Topics to capture:
 ---
 
 _No research yet._
+
+## 2026-02-19 — Account tradability probe summary
+
+Findings from controlled paper probes:
+- PASS: EURUSD, GBPUSD (IDEALPRO)
+- FAIL: USDJPY (currency leverage permission constraint)
+- FAIL: BTCUSD/ETHUSD (PAXOS requires cash quantity order semantics)
+- FAIL/Pending: CSPX, VUAA (no fill in test window; likely exchange/session/routing constraints)
+
+Actionable implication:
+- For rapid bot-learning cycles and execution validation, use FX symbols with confirmed permissions.
+- Keep ETF universe as secondary track with explicit session/routing handling.

--- a/spybot/journal.py
+++ b/spybot/journal.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def append_signal(*, path: str = "trades.md", symbol: str, action: str, reason: str) -> None:
+    p = Path(path)
+    line = f"- Signal (UTC { _now_utc() }): {symbol} | {action} | {reason}\n"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as f:
+        f.write(line)

--- a/spybot/runner.py
+++ b/spybot/runner.py
@@ -85,13 +85,17 @@ def run_bot_once(cfg: Config, *, dry_run: bool = False) -> None:
         sig = strat.generate(bars, current_position_value=current_value, target_position_value=max_value)
 
         log.info(f"Signal: {sig.action} ({sig.reason})")
+        from .journal import append_signal
+        append_signal(symbol=cfg.market.symbol, action=sig.action, reason=sig.reason)
 
         if sig.action == "BUY":
             res = broker.place_target_value_order(cfg.market.symbol, sig.target_position_value, paper_only=cfg.run.paper_only)
             log.info(f"Order: {res.status} id={res.order_id}")
+            append_signal(symbol=cfg.market.symbol, action=f"ORDER_{res.status}", reason=f"order_id={res.order_id}")
         elif sig.action == "SELL":
             res = broker.place_target_value_order(cfg.market.symbol, 0.0, paper_only=cfg.run.paper_only)
             log.info(f"Order: {res.status} id={res.order_id}")
+            append_signal(symbol=cfg.market.symbol, action=f"ORDER_{res.status}", reason=f"order_id={res.order_id}")
         else:
             log.info("No action.")
 


### PR DESCRIPTION
## What
Implement step 3 from the agreed plan: log every run signal/action and capture learnings from paper probing.

### Changes
- Add `spybot/journal.py` with append-only signal journaling helper.
- Update `runner.py` to append:
  - signal decision per run (`BUY/SELL/HOLD` + reason)
  - order execution status events when an order is attempted
- Update `lessons.md` with tradability constraints learned from paper probes.
- Update `research.md` with account-level tradability findings and implications.

## Why
You asked to start with logging/learning visibility first so progress is observable and cumulative.

## Risk assessment
- Low risk: additive logging/documentation changes only.
- No strategy parameter changes.
- No live-trading behavior changes.

## Reversibility
- Remove `spybot/journal.py` and runner hooks if needed.
- Logs are append-only text and can be archived.
